### PR TITLE
jquery live is deprecated, changed to on

### DIFF
--- a/plugins/pybox/action-notify-complete.php
+++ b/plugins/pybox/action-notify-complete.php
@@ -6,7 +6,7 @@ $problem = $_POST["problem"];
 
   
 global $current_user;
-get_currentuserinfo();
+wp_get_current_user();
 global $wpdb;
 
 if ( is_user_logged_in() ) {

--- a/plugins/pybox/action-send-message.php
+++ b/plugins/pybox/action-send-message.php
@@ -80,7 +80,7 @@ if ($user < 0) {
  }
 
 global $current_user;
-get_currentuserinfo();
+wp_get_current_user();
 $user_email = $current_user->user_email;
 
 global $wpdb;

--- a/plugins/pybox/db-entire-history.php
+++ b/plugins/pybox/db-entire-history.php
@@ -23,7 +23,7 @@ function dbEntireHistory($limit, $sortname, $sortorder, $req=NULL) {
 		       's'=> __t('Saved.'));
    
    global $current_user;
-   get_currentuserinfo();
+   wp_get_current_user();
    global $wpdb;
    
    if ( !is_user_logged_in() ) 

--- a/plugins/pybox/plugin-hooks.php
+++ b/plugins/pybox/plugin-hooks.php
@@ -11,6 +11,7 @@ function pyBoxInit() {
  wp_enqueue_script("jquery-ui-draggable");
  wp_enqueue_script("jquery-ui-sortable"); 
  wp_enqueue_script("jquery-ui-resizable");
+ wp_enqueue_script("jquery-touch-punch");
  wp_enqueue_style( 'wp-jquery-ui-dialog' );
 }
 

--- a/plugins/pybox/plugin-main.php
+++ b/plugins/pybox/plugin-main.php
@@ -143,7 +143,6 @@ PRIMARY KEY  (ID)
 
 }
 
-wp_enqueue_script( 'jquery-touch-punch' );
 
 require_once("sweetcodes.php");
 require_once("shortcodes-exercises.php");

--- a/plugins/pybox/plugin-utilities.php
+++ b/plugins/pybox/plugin-utilities.php
@@ -382,7 +382,7 @@ function JQpopUp($linkText, $popup) {
 
 function getCompleted($problem) {
   global $current_user;
-  get_currentuserinfo();
+  wp_get_current_user();
   global $wpdb;
 
   if ( ! is_user_logged_in() )
@@ -401,7 +401,7 @@ function getCompleted($problem) {
 
 function getStudents($with_hidden = false) {
   global $current_user;
-  get_currentuserinfo();
+  wp_get_current_user();
 
   if ( ! is_user_logged_in() )
     return array();

--- a/plugins/pybox/pybox.js
+++ b/plugins/pybox/pybox.js
@@ -1,8 +1,8 @@
 $ = jQuery;
 
 var registerclick = function(selector, callback) {
-  $(selector).live('touchstart', callback);
-  $(selector).live('click', callback);
+    $(document).on('touchstart', selector, callback);
+    $(document).on('click', selector, callback);
 };
 
 function __t(s) {
@@ -412,13 +412,13 @@ registerclick(".hintboxlink", function(e) {
   $("#hintbox"+n).css("display","none");
 });   
 
-$(".pbform").live("submit", pbFormSubmit);
-$(".selectmore").live("change", pbSelectChange);
+$(document).on("submit", ".pbform", pbFormSubmit);
+$(document).on("change", ".selectmore", pbSelectChange);
 registerclick('.entry-content a', stayHere);
 registerclick('.hintbox', stayHere);
 registerclick('.hintbox a', stayHere);
 registerclick('.pyflexClose', function (e) {historyClick($(e.target).closest('.pybox').find('input[name="pyId"]').val(),"");});
-$('.flexigrid pre').live('dblclick', function (e) {
+$(document).on('dblclick', '.flexigrid pre', function (e) {
     jq = $(e.target);
     id = jq.closest('.pybox').find('input[name="pyId"]').val();
     code = jq.html();


### PR DESCRIPTION
According to https://api.jquery.com/live/ `.live()` is deprecated. In my setup jquery turns out to be 3.5.1 (it is not clear to me who is responsible for loading that version...) and the `.live` call gives an error. Thus, I ported to the new API based on `.on()`.