### PR TITLE
wp_enqueue_script called too early

### DIFF
--- a/plugins/pybox/plugin-hooks.php
+++ b/plugins/pybox/plugin-hooks.php
@@ -11,6 +11,7 @@ function pyBoxInit() {
  wp_enqueue_script("jquery-ui-draggable");
  wp_enqueue_script("jquery-ui-sortable"); 
  wp_enqueue_script("jquery-ui-resizable");
+ wp_enqueue_script("jquery-touch-punch");
  wp_enqueue_style( 'wp-jquery-ui-dialog' );
 }
 

--- a/plugins/pybox/plugin-main.php
+++ b/plugins/pybox/plugin-main.php
@@ -143,7 +143,6 @@ PRIMARY KEY  (ID)
 
 }
 
-wp_enqueue_script( 'jquery-touch-punch' );
 
 require_once("sweetcodes.php");
 require_once("shortcodes-exercises.php");


### PR DESCRIPTION
It should be called together with others, since in `plugin-main.php` is too early.